### PR TITLE
Known hosts fix

### DIFF
--- a/oit_ds_prefect_tools/object_storage.py
+++ b/oit_ds_prefect_tools/object_storage.py
@@ -19,6 +19,7 @@ the constructor indicated in the list above, with some exceptions:
 """
 
 import io
+import uuid
 from typing import BinaryIO, Union
 import os
 import stat
@@ -181,10 +182,12 @@ def _make_ssh_key(connection_info):
 
 def _load_known_hosts(ssh_client, connection_info):
     if 'known_hosts' in connection_info:
+        hosts_filename = os.path.expanduser(f'~/.ssh/prefect_known_hosts_{uuid.uuid4()}')
         known_hosts = util.get_config_value(connection_info['known_hosts'])
-        with open("flow_known_hosts", 'w', encoding="ascii") as fileobj:
+        with open(hosts_filename, 'w', encoding="ascii") as fileobj:
             fileobj.write('\n'.join(known_hosts))
-        ssh_client.load_host_keys('flow_known_hosts')
+        ssh_client.load_host_keys(hosts_filename)
+        os.remove(hosts_filename)
         del connection_info['known_hosts']
         if 'look_for_keys' not in connection_info:
             connection_info['look_for_keys'] = False

--- a/oit_ds_prefect_tools/object_storage.py
+++ b/oit_ds_prefect_tools/object_storage.py
@@ -184,6 +184,8 @@ def _load_known_hosts(ssh_client, connection_info):
     if 'known_hosts' in connection_info:
         hosts_filename = os.path.expanduser(f'~/.ssh/prefect_known_hosts_{uuid.uuid4()}')
         known_hosts = util.get_config_value(connection_info['known_hosts'])
+        if not os.path.exists(os.path.expanduser('~/.ssh/')):
+            os.mkdir(os.path.expanduser('~/.ssh/'))
         with open(hosts_filename, 'w', encoding="ascii") as fileobj:
             fileobj.write('\n'.join(known_hosts))
         ssh_client.load_host_keys(hosts_filename)


### PR DESCRIPTION
Create unique known hosts files for each task run to avoid rare conflicts where one task run tries to access the file while another is writing it