### PR TITLE
DS-567 #comment Added main branch protections

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,41 +8,10 @@ Install the latest version with pip from the repo: `oit_ds_prefect_tools @ git+h
 
 You can also add `@tag` to get a specific version
 
-## Development
-
-Clone to your local machine and create a new branch.
-
-If making changes as part of another project, install oit_ds_prefect_tools in that project with `pip install -e path/to/repo`. This will allow you to edit this repo and have it automatically update in the installed project.
-
-When ready, increment the version number is setup.cfg and merge into main. Tag the commit with the same version number and create a Github release for it.
-
-Be sure to follow [Semantic Versioning](https://semver.org/).
-
 ## Deployment to Prefect Flows
 
-To update the version of Prefect Tools used in the docker images of one or more Prefect flow repos (or the version of any Python package for that matter), the idea is to simply delete the cached images and rebuild them: assuming you import this package without a specific version number, rebuilding the image from scratch will result in pulling the latest version of the package.
+To update the version of Prefect Tools used in the docker images of one or more Prefect flow repos (or the version of any Python package for that matter), all you have to do is rebuild the image without using the docker cache: assuming you import this package without a specific version number, rebuilding the image from scratch will result in pulling the latest version of the package.
 
-### Updating packages in a single image
+To do this, simply use the [Image Builder Repo](https://github.com/UCBoulder/oit-ds-tools-image-builder)
 
-First, rebuild your local image with the `--no-cache` option and re-push it to Artifactory, for example:
-
-```
-cd image
-docker build -f Dockerfile -t oit-data-services-docker-local.artifactory.colorado.edu/oit-ds-flows-ata:v1 --no-cache .
-cd ..
-make docker-image VERSION=v1
-```
-
-Then, re-build the image from the flow's repo on your local machine, for example: `make docker-image VERSION=v1`
-
-Finally, run the same command from step 1 on the agent machine to remove the image and force Prefect to re-pull it next run from Artifactory.
-
-### Updating packages in all images
-
-If you make a bugfix in Prefect Tools and want to update all flows simultaneously to use the newest version, do this. If you want a particular flow to still use an old version of any package, specify the package version in your requirements.txt file.
-
-First, remove all cached images from your local machine: `docker system prune -a`
-
-Ensure you have all the flow repos for these images cloned to your computer, then rebuild the image for each one. For example (this assumes every image is on v1! grep carefully!):
-
-`ls | grep oit-ds-flows | xargs -n 1 -I % sh -c 'cd % && make docker-image VERSION=v1'`
+If you rebuild a lot of images, you may want to run `docker system prune -a` on the agent machine to ensure storage is freed up.


### PR DESCRIPTION
So, I investigated the idea of auto-deploying the main branch of flow repos, but it seemed like more work/complexity than value, especially considering how easy it is to deploy flows from the command line. So instead I have added some main branch protections to prevent someone from accidentally deploying a main branch flow when they aren't an exact match with what's in Github. Let me know what you think of this approach!

I also did some reorganizing for clarity and removed the addition of flow retries, which don't work with our Prefect configuration (I'll add task retries in another PR).