### PR TITLE
UCBDE-189 Add path as an argument to Deployment.build_from_flow()

### DIFF
--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -224,6 +224,7 @@ def _deploy(flow_filename, flow_function_name, options):
             infrastructure=docker,
             storage=storage,
             apply=True,
+            path="/",
         )
         print(f"Deployed {deployment.name} using docker image {image_uri}")
 


### PR DESCRIPTION
Relevant issue in the prefect repo: https://github.com/PrefectHQ/prefect/issues/8710

Due to a change in a recent version of s3fs (2023.3.0), prefect fails to find the source code for a flow unless the path argument has a trailing slash. Our ucb_prefect_tools package has this as a dependency.

Without this argument set, if you deploy using the most recent version you'll encounter an error like the following:
```
Flow could not be retrieved from deployment.
Traceback (most recent call last):
  File "<frozen importlib._bootstrap_external>", line 846, in exec_module
  File "<frozen importlib._bootstrap_external>", line 982, in get_code
  File "<frozen importlib._bootstrap_external>", line 1039, in get_data
FileNotFoundError: [Errno 2] No such file or directory: 'classroom_capture_users_report.py'
```

This PR adds a default for the path argument in `Deployment.build_from_flow()` which our deployment CLI relies upon.

We haven't been seeing this issue broadly across our repos currently because we haven't needed to rebuild that many docker images. I encountered this when working with  a dev image, but as we update over time, we'll start running into it. Other note that feels important: if/when the maintainers of s3fs update things, it's possible this quick fix could break? Perhaps not, but worth watching over the next few weeks.