### PR TITLE
Add comparer and associated unit tests

### DIFF
--- a/ucb_prefect_tools/comparer.py
+++ b/ucb_prefect_tools/comparer.py
@@ -1,0 +1,200 @@
+"""Tool for comparing two dataframes for testing and validation"""
+
+import os
+import itertools
+from typing import Callable, Tuple
+
+import pandas as pd
+
+
+def _list2str(listlike):
+    return ", ".join(list(listlike))
+
+
+def _subsets(items, max_size=10):
+    result = []
+    max_size = min(max_size, len(items) - 1)
+    for i in range(1, max_size + 1):
+        result.extend([list(i) for i in itertools.combinations(items, i)])
+    return result
+
+
+def _standardize(dataframe):
+    dataframe = dataframe.copy()
+    for col in dataframe.columns.tolist():
+        try:
+            dataframe[col] = dataframe[col].dt.strftime("%Y-%m-%dT%H:%M:%S")
+            continue
+        except AttributeError:
+            pass
+        # Not a datetime, try number
+        try:
+            dataframe[col] = dataframe[col].round(2).astype("Float64")
+            continue
+        except (AttributeError, TypeError):
+            pass
+        # Not a number, continue
+    # Now convert everything to standardized strings
+    dataframe = dataframe.astype("object").fillna("").astype("string")
+    return dataframe.drop_duplicates()
+
+
+def _changes_in_column(merged_df, column, top_n):
+    diff = merged_df[merged_df[f"{column}_x"] != merged_df[f"{column}_y"]]
+    if len(diff):
+        combos = column + ": " + diff[f"{column}_x"] + " => " + diff[f"{column}_y"]
+        data = pd.DataFrame({f"change in {column}": combos, "count": 1})
+        return dict(
+            data.groupby(f"change in {column}")["count"]
+            .count()
+            .sort_values(ascending=False)
+            .reset_index()
+            .head(top_n)
+            .values.tolist()
+        )
+    return {}
+
+
+def auto_merge(left: pd.DataFrame, right: pd.DataFrame) -> Tuple[pd.DataFrame, dict]:
+    """Attempts to merge the two dataframes by auto-identifying distinguishing key columns. Returns
+    the merged dataframe and a dict of metrics related to the process. Assumes the two dataframes
+    have identical columns."""
+
+    best = 0
+    key_columns = right.columns.tolist()
+    goal = len(right.drop_duplicates())
+    for candidates in _subsets(right.columns.tolist(), max_size=4):
+        distinct_count = len(right[candidates].drop_duplicates())
+        if distinct_count > best:
+            best = distinct_count
+            key_columns = candidates
+            if distinct_count >= goal:
+                break
+    merged = left.merge(right, on=key_columns, how="outer", indicator=True)
+    left_only = len(merged[merged["_merge"] == "left_only"])
+    right_only = len(merged[merged["_merge"] == "right_only"])
+    both = merged[merged["_merge"] == "both"].drop(columns=["_merge"])
+    metrics = {"merged_rows": len(both), "merge_key_columns": _list2str(key_columns)}
+    if left_only:
+        metrics["unmerged_left_rows"] = left_only
+    if right_only:
+        metrics["unmerged_right_rows"] = right_only
+    return both, metrics
+
+
+def reconcile(
+    left: pd.DataFrame, right: pd.DataFrame
+) -> Tuple[pd.DataFrame, pd.DataFrame, dict]:
+    """Returns both dataframes with only matching columns, duplicates removed, and values
+    standardized to comparable strings. Also returns a dict with various metrics gathered
+    during this process"""
+
+    metrics = {}
+    if right.index.names[0]:
+        metrics["right_index_reset"] = _list2str(right.index.names)
+        right = right.reset_index()
+    if left.index.names[0]:
+        metrics["left_index_reset"] = _list2str(left.index.names)
+        left = left.reset_index()
+    left_only_columns = [
+        i for i in left.columns.tolist() if i not in right.columns.tolist()
+    ]
+    right_only_columns = [
+        i for i in right.columns.tolist() if i not in left.columns.tolist()
+    ]
+    columns = [i for i in left.columns.tolist() if i in right.columns.tolist()]
+    if left_only_columns:
+        metrics["left_only_columns"] = _list2str(left_only_columns)
+    if right_only_columns:
+        metrics["right_only_columns"] = _list2str(right_only_columns)
+    if not columns:
+        metrics["coerced_merge"] = True
+        left.columns = right.columns.tolist()
+        columns = right.columns.tolist()
+    new_left = _standardize(left[columns])
+    if len(new_left) < len(left):
+        metrics["left_duplicates"] = len(left) - len(new_left)
+    new_right = _standardize(right[columns])
+    if len(new_right) < len(right):
+        metrics["right_duplicates"] = len(right) - len(new_right)
+    return new_left, new_right, metrics
+
+
+def compare_column(left: pd.DataFrame, right: pd.DataFrame, column: str) -> dict:
+    """Generates a detailed break down of the differences between two dataframes on a specific
+    column. Returns this data as a dict that also includes various metrics collected throughout
+    this process"""
+
+    left, right, reconcile_metrics = reconcile(left, right)
+    merged, merge_metrics = auto_merge(left, right)
+    changes = _changes_in_column(merged, column, 10)
+    out = {}
+    out.update(reconcile_metrics)
+    out.update(merge_metrics)
+    out.update(changes)
+    return out
+
+
+def compare(left: pd.DataFrame, right: pd.DataFrame) -> dict:
+    """Compares the two dataframes and returns a summary of differences"""
+
+    left, right, metrics = reconcile(left, right)
+
+    # Compare
+    merged = left.merge(right, on=right.columns.tolist(), how="outer", indicator=True)
+    left_cnt = len(merged[merged["_merge"] == "left_only"])
+    right_cnt = len(merged[merged["_merge"] == "right_only"])
+    both_cnt = len(merged[merged["_merge"] == "both"])
+    metrics["left_only_rows"] = left_cnt
+    metrics["right_only_rows"] = right_cnt
+    metrics["matched_rows"] = both_cnt
+
+    # If different, merge for further comparison
+    if left_cnt or right_cnt:
+        merged, merge_metrics = auto_merge(left, right)
+        metrics.update(merge_metrics)
+    else:
+        return metrics
+
+    # Get a detailed breakdown of differences
+    if not merged.empty:
+        for column in [
+            i.removesuffix("_x") for i in merged.columns.tolist() if i.endswith("_x")
+        ]:
+            metrics.update(_changes_in_column(merged, column, 5))
+    return metrics
+
+
+def bulk_compare(
+    left_filepaths: list[str], right_filepaths: list[str], df_loader: Callable
+) -> pd.DataFrame:
+    """Compares left files with right files in order, loading the files into DataFrames using the
+    df_loader callable. Returns a DataFrame with columns filename, measure, value giving the metrics
+    collected for each pair of files with a matching filename."""
+
+    left_filenames = [os.path.basename(i) for i in left_filepaths]
+    right_filenames = [os.path.basename(i) for i in right_filepaths]
+    left_only = [i for i in left_filenames if i not in right_filenames]
+    right_only = [i for i in right_filenames if i not in left_filenames]
+    shared_left_filepaths = [
+        p for p, n in zip(left_filepaths, left_filenames) if n in right_filenames
+    ]
+    shared_right_filepaths = [
+        p for p, n in zip(right_filepaths, right_filenames) if n in left_filenames
+    ]
+    out = pd.DataFrame(data=[], columns=["filename", "measure", "value"])
+    if left_only:
+        out.loc[len(out.index)] = [None, "left_only_files", _list2str(left_only)]
+    if right_only:
+        out.loc[len(out.index)] = [None, "right_only_files", _list2str(right_only)]
+    for left, right in zip(shared_left_filepaths, shared_right_filepaths):
+        metrics = compare(df_loader(left), df_loader(right))
+        new_rows = pd.DataFrame(
+            {
+                "filename": os.path.basename(left),
+                "measure": metrics.keys(),
+                "value": metrics.values(),
+            }
+        )
+        out = pd.concat(out, new_rows, ignore_index=True)
+    return out

--- a/ucb_prefect_tools/tests/test_comparer.py
+++ b/ucb_prefect_tools/tests/test_comparer.py
@@ -1,0 +1,142 @@
+"""Unit tests for the comparer module"""
+
+import pandas as pd
+import pytest
+
+from ucb_prefect_tools import comparer
+
+# pylint:disable=protected-access
+# pylint:disable=redefined-outer-name
+
+
+def assert_dataframes_are_equal(left, right):
+    """Asserts if the two dataframes have equal values. Useful for checking task output."""
+
+    assert left.astype("object").fillna("").to_dict("records") == right.astype(
+        "object"
+    ).fillna("").to_dict("records")
+
+
+@pytest.fixture
+def sample_data():
+    """Fixture that returns a sample pandas DataFrame."""
+
+    data = {
+        "name": ["Alice", "Bob", "Charlie"],
+        "age": [25, 30, 35],
+        "date": [pd.Timestamp("2022-01-01")] * 3,
+        "value": [1.234, 2.345, 3.456],
+    }
+    return pd.DataFrame(data)
+
+
+@pytest.fixture
+def standardized_data():
+    """Fixture that returns a sample pandas DataFrame in standardized string values format"""
+
+    return pd.DataFrame(
+        {
+            "name": ["Alice", "Bob", "Charlie"],
+            "age": ["25.0", "30.0", "35.0"],
+            "date": ["2022-01-01T00:00:00"] * 3,
+            "value": ["1.23", "2.35", "3.46"],
+        }
+    )
+
+
+def test_list2str():
+    """Test function for `_list2str` method, which converts a list into a simple string
+    representation."""
+
+    assert comparer._list2str([]) == ""
+    assert comparer._list2str(["a"]) == "a"
+    assert comparer._list2str(["a", "b"]) == "a, b"
+
+
+def test_subsets():
+    """Tests the `_subsets` method which returns a list of subsets from a list where subset size is
+    between 0 and the size of the original list"""
+
+    assert comparer._subsets([1, 2]) == [[1], [2]]
+    assert comparer._subsets([1, 2, 3]) == [[1], [2], [3], [1, 2], [1, 3], [2, 3]]
+
+
+def test_standardize(sample_data, standardized_data):
+    """Tests the `_standardize` method which converts a DataFrame's values to strings in a way
+    that makes it easy to compare with other DataFrames"""
+
+    actual = comparer._standardize(sample_data)
+    assert_dataframes_are_equal(actual, standardized_data)
+
+
+def test_changes_in_column(standardized_data):
+    """Tests the `_changes_in_column` method which returns a dict of the most frequent changes in
+    values in the given column"""
+
+    left = standardized_data
+    right = left.copy()
+    right.loc[0, "date"] = "2022-01-02T00:00:00"
+    right.loc[1:2, "date"] = "2022-01-03T00:00:00"
+    merged_df = pd.merge(left, right, on="name")
+
+    # Test top_n > actual changes
+    expected = {
+        "date: 2022-01-01T00:00:00 => 2022-01-03T00:00:00": 2,
+        "date: 2022-01-01T00:00:00 => 2022-01-02T00:00:00": 1,
+    }
+    assert comparer._changes_in_column(merged_df, "date", 10) == expected
+
+    # Test top_n < actual changes
+    expected = {
+        "date: 2022-01-01T00:00:00 => 2022-01-03T00:00:00": 2,
+    }
+    assert comparer._changes_in_column(merged_df, "date", 1) == expected
+
+
+def test_auto_merge(sample_data):
+    """Tests the `auto_merge` method merges two sample dataframes as expected"""
+
+    left = sample_data
+    right = sample_data.copy()
+    right["name"] = ["Alice", "Bob", "David"]
+    merged, metrics = comparer.auto_merge(left, right)
+
+    # Check merged
+    expected = pd.DataFrame(
+        {
+            "name": ["Alice", "Bob"],
+            "age_x": [25, 30],
+            "age_y": [25, 30],
+            "date_x": [pd.Timestamp("2022-01-01")] * 2,
+            "date_y": [pd.Timestamp("2022-01-01")] * 2,
+            "value_x": [1.234, 2.345],
+            "value_y": [1.234, 2.345],
+        }
+    )
+    assert_dataframes_are_equal(merged, expected)
+
+    # Check metrics
+    expected = {
+        "merged_rows": 2,
+        "unmerged_right_rows": 1,
+        "unmerged_left_rows": 1,
+        "merge_key_columns": "name",
+    }
+    assert metrics == expected
+
+
+def test_reconcile(sample_data, standardized_data):
+    """Tests the `reconcile` method properly trims two dataframes down to comparable values"""
+
+    left = sample_data
+    right = sample_data.copy()
+    # Add a duplicate row
+    right.loc[len(right.index)] = right.loc[0]
+    # Add an extra column
+    left["test"] = "test"
+
+    new_left, new_right, metrics = comparer.reconcile(left, right)
+    assert_dataframes_are_equal(new_left, standardized_data)
+    assert_dataframes_are_equal(new_right, standardized_data)
+    expected = {"left_only_columns": "test", "right_duplicates": 1}
+    assert metrics == expected


### PR DESCRIPTION
Unit tests focus on low-level functions, since high-level functions are pretty basic wrappers of these. I did test the high-level functions as well.

The intent here is that by returning information in dicts, it can be easily adapted to other formats (like thrown into a DataFrame or pretty-printed or whatever). So while you can use this module in your own manual testing and validation, we could also easily integrate it with our next-gen cacheing system that we have planned: https://cu-oda.atlassian.net/browse/UCBDE-63?search_id=23f1d8af-8177-4ccd-89a8-6433d7a915ce

This is why I added this to the ucb_prefect_tools library, even though it doesn't directly relate to it right now. This paves the way for us to automatically generate diff reports whenever we cache a dataframe.

My approach to comparing dataframes was grounded in the scenarios I believe we face most often in higher ed: where we have fairly similar before/after datasets, but we don't always know what the primary keys should be, and we don't really care about a lot of floating point precision. So I wrote my code to highlight impactful differences, while ignoring what is likely to be just noise (like differences in data types, small numerical differences, etc.).

Let me know what you think!