### PR TITLE
Fixes for upgrade to Prefect 2.10

### DIFF
--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -14,12 +14,12 @@ import asyncio
 import uuid
 
 from prefect import task, get_run_logger, tags, context
-from prefect.utilities.filesystem import set_default_ignore_file
+from prefect.utilities.filesystem import create_default_ignore_file
 from prefect.deployments import Deployment
 from prefect.filesystems import RemoteFileSystem
 from prefect.blocks.system import Secret, JSON
 from prefect.infrastructure.docker import DockerContainer
-from prefect.client import get_client
+from prefect.client.orchestration import get_client
 import git
 import pytz
 
@@ -143,7 +143,7 @@ def _deploy(flow_filename, flow_function_name, options):
             docker_label = options[1]
         else:
             raise ValueError(f"Unrecognized option: {options[0]}")
-    if set_default_ignore_file(LOCAL_FLOW_FOLDER):
+    if create_default_ignore_file(LOCAL_FLOW_FOLDER):
         print("Created default .prefectignore file")
     flow_filename = os.path.basename(flow_filename)
     if not os.path.exists(os.path.join(LOCAL_FLOW_FOLDER, flow_filename)):


### PR DESCRIPTION
Prefect changed a few things sneakily between 2.8 and 2.10. This update to our tools package addresses both the issues I found in my audit.

1: prefect.utilities.filesystem.set_default_ignore_file has had its name changed to create_default_ignore_file

2: prefect.client.get_client has been relocated to prefect.client.orchestration.get_client