### PR TITLE
UCBDE-64 Add task-level retries

### DIFF
--- a/ucb_prefect_tools/database.py
+++ b/ucb_prefect_tools/database.py
@@ -27,7 +27,7 @@ from . import util
 # System-agnostic tasks
 
 
-@task(name="database.sql_extract")
+@task(name="database.sql_extract", retries=3, retry_delay_seconds=10 * 60)
 def sql_extract(
     sql_query: str,
     connection_info: dict,
@@ -108,7 +108,7 @@ def insert(
     )
 
 
-@task(name="database.update")
+@task(name="database.update", retries=3, retry_delay_seconds=10 * 60)
 def update(
     dataframe: pd.DataFrame,
     table_identifier: str,
@@ -766,7 +766,12 @@ def get_update(system_type, connection_func):
             cursor = conn.cursor()
 
             _execute_statements(
-                system_type, conn, cursor, host, pre_update_statements, pre_update_params
+                system_type,
+                conn,
+                cursor,
+                host,
+                pre_update_statements,
+                pre_update_params,
             )
 
             try:
@@ -839,7 +844,9 @@ def get_execute_sql(system_type, connection_func):
             else:
                 host = connection_info["host"]
             cursor = conn.cursor()
-            _execute_statements(system_type, conn, cursor, host, sql_statement, query_params)
+            _execute_statements(
+                system_type, conn, cursor, host, sql_statement, query_params
+            )
             conn.commit()
 
     return do_execute_sql

--- a/ucb_prefect_tools/object_storage.py
+++ b/ucb_prefect_tools/object_storage.py
@@ -61,7 +61,7 @@ def _switch(connection_info, **kwargs):
     raise ValueError(f'System type "{connection_info["system_type"]}" is not supported')
 
 
-@task(name="object_storage.get")
+@task(name="object_storage.get", retries=3, retry_delay_seconds=10 * 60)
 def get(object_name: str, connection_info: dict) -> bytes:
     """Returns the bytes content for the given file/object on the identified system. Raises
     FileNotFoundError if the file could not be found."""
@@ -71,7 +71,7 @@ def get(object_name: str, connection_info: dict) -> bytes:
     return function(object_name, info)
 
 
-@task(name="object_storage.put")
+@task(name="object_storage.put", retries=3, retry_delay_seconds=10 * 60)
 def put(
     binary_object: Union[BinaryIO, bytes], object_name: str, connection_info: dict
 ) -> None:
@@ -86,7 +86,7 @@ def put(
     function(binary_object, object_name, info)
 
 
-@task(name="object_storage.remove")
+@task(name="object_storage.remove", retries=3, retry_delay_seconds=10 * 60)
 def remove(object_name: str, connection_info: dict) -> None:
     """Removes the identified file/object."""
 
@@ -97,7 +97,7 @@ def remove(object_name: str, connection_info: dict) -> None:
     function(object_name, info)
 
 
-@task(name="object_storage.list_names")
+@task(name="object_storage.list_names", retries=3, retry_delay_seconds=10 * 60)
 def list_names(connection_info: dict, prefix: str = None) -> list[str]:
     """Returns a list of object or file names in the given folder. Filters by object name prefix,
     which includes directory path for file systems. Folders are not included; non-recursive."""
@@ -109,7 +109,7 @@ def list_names(connection_info: dict, prefix: str = None) -> list[str]:
     return function(info)
 
 
-@task(name="object_storage.store_dataframe")
+@task(name="object_storage.store_dataframe", retries=3, retry_delay_seconds=10 * 60)
 def store_dataframe(
     dataframe: pd.DataFrame, object_name: str, connection_info: dict
 ) -> None:
@@ -130,7 +130,7 @@ def store_dataframe(
     function(data, object_name, info)
 
 
-@task(name="object_storage.retrieve_dataframe")
+@task(name="object_storage.retrieve_dataframe", retries=3, retry_delay_seconds=10 * 60)
 def retrieve_dataframe(object_name: str, connection_info: dict) -> pd.DataFrame:
     """Writes the given dataframe to the identified storage system. The storage method and format
     should be considered opaque; reading the data should only be done with retrieve_dataframe.

--- a/ucb_prefect_tools/rest.py
+++ b/ucb_prefect_tools/rest.py
@@ -25,7 +25,7 @@ import pandas as pd
 from .util import sizeof_fmt
 
 
-@task(name="rest.get")
+@task(name="rest.get", retries=3, retry_delay_seconds=10 * 60)
 def get(
     endpoint: str,
     connection_info: dict,
@@ -63,7 +63,7 @@ def post(
     )
 
 
-@task(name="rest.put")
+@task(name="rest.put", retries=3, retry_delay_seconds=10 * 60)
 def put(
     endpoint: str, connection_info: dict, params=None, data=None, json=None, files=None
 ):
@@ -89,7 +89,7 @@ def patch(
     )
 
 
-@task(name="rest.delete")
+@task(name="rest.delete", retries=3, retry_delay_seconds=10 * 60)
 def delete(
     endpoint: str, connection_info: dict, params=None, data=None, json=None, files=None
 ):
@@ -102,7 +102,7 @@ def delete(
     )
 
 
-@task(name="rest.get_many")
+@task(name="rest.get_many", retries=3, retry_delay_seconds=10 * 60)
 def get_many(
     endpoints: list[str],
     connection_info: dict,
@@ -233,7 +233,7 @@ def post_many(
     )
 
 
-@task(name="rest.put_many")
+@task(name="rest.put_many", retries=3, retry_delay_seconds=10 * 60)
 def put_many(
     endpoints: list[str],
     connection_info: dict,


### PR DESCRIPTION
Added task retries to all idempotent tasks, with a delay of 10 minutes, trying 3 additional times (so up 30 minutes after initial attempt). My reasoning for having such long delays between retries is that we really want connection issues to resolve with retries, and a typical outage of an external system would hopefully resolve in 30 minutes tops. I don't want to retry every minute or so because it seems good to keep retries to a minimum while also maximizing the chances of a successful execution. Let me know what you think of this strategy!

Left retries off of rest.delete_many because presumably if this fails it could delete some and not others and then all subsequent attempts would also fail by definition in attempting to delete what was already deleted, so retrying doesn't seem like a good fit for this task.