### PR TITLE
UCBDE-245 address OSErrors when multiple put requests are occurring simultaneously

### DIFF
--- a/ucb_prefect_tools/object_storage.py
+++ b/ucb_prefect_tools/object_storage.py
@@ -211,9 +211,9 @@ def _sftp_chdir(sftp, remote_directory):
         sftp.chdir(remote_directory)  # sub-directory exists
     except IOError:
         dirname, basename = os.path.split(remote_directory.rstrip("/"))
-        _sftp_chdir(sftp, dirname)  # make parent directories
 
         try:
+            _sftp_chdir(sftp, dirname)  # make parent directories
             sftp.mkdir(basename)  # sub-directory missing, so created it
         except OSError:
             pass
@@ -299,18 +299,6 @@ def sftp_remove(file_path: str, connection_info: dict) -> None:
     _load_known_hosts(ssh, connection_info)
     with _sftp_connection(ssh, connection_info) as sftp:
         sftp.remove(file_path)
-
-
-def sftp_rmdir(dir_path: str, connection_info: dict) -> None:
-    """Removes a directory if it exists.
-    dir_path must exist and be empty, otherwise an error will be raised.
-    """
-
-    _make_ssh_key(connection_info)
-    ssh = SSHClient()
-    _load_known_hosts(ssh, connection_info)
-    with _sftp_connection(ssh, connection_info) as sftp:
-        sftp.rmdir(dir_path)
 
 
 def sftp_list(connection_info: dict, file_prefix: str = "./") -> list[str]:

--- a/ucb_prefect_tools/object_storage.py
+++ b/ucb_prefect_tools/object_storage.py
@@ -207,6 +207,7 @@ def _sftp_chdir(sftp, remote_directory):
     if remote_directory == "":
         # top-level relative directory must exist
         return
+
     try:
         sftp.chdir(remote_directory)  # sub-directory exists
     except IOError:
@@ -214,11 +215,15 @@ def _sftp_chdir(sftp, remote_directory):
 
         try:
             _sftp_chdir(sftp, dirname)  # make parent directories
+        except OSError:
+            pass
+
+        try:
             sftp.mkdir(basename)  # sub-directory missing, so created it
         except OSError:
             pass
-        finally:
-            sftp.chdir(basename)
+
+        sftp.chdir(basename)
 
 
 @contextmanager

--- a/ucb_prefect_tools/object_storage.py
+++ b/ucb_prefect_tools/object_storage.py
@@ -213,10 +213,7 @@ def _sftp_chdir(sftp, remote_directory):
     except IOError:
         dirname, basename = os.path.split(remote_directory.rstrip("/"))
 
-        try:
-            _sftp_chdir(sftp, dirname)  # make parent directories
-        except OSError:
-            pass
+        _sftp_chdir(sftp, dirname)  # make parent directories
 
         try:
             sftp.mkdir(basename)  # sub-directory missing, so created it

--- a/ucb_prefect_tools/object_storage.py
+++ b/ucb_prefect_tools/object_storage.py
@@ -211,8 +211,13 @@ def _sftp_chdir(sftp, remote_directory):
     except IOError:
         dirname, basename = os.path.split(remote_directory.rstrip("/"))
         _sftp_chdir(sftp, dirname)  # make parent directories
-        sftp.mkdir(basename)  # sub-directory missing, so created it
-        sftp.chdir(basename)
+        
+        try:
+            sftp.mkdir(basename)  # sub-directory missing, so created it
+        except OSError:
+            pass
+        finally:
+            sftp.chdir(basename)
 
 
 @contextmanager


### PR DESCRIPTION
# Purpose

`object_storage.put` has the ability to create the corresponding target directory for a filepath if the directory doesn't already exist. However, in instances where `put` is called asynchronously, the tasks will attempt to each create the necessary directory on their own, and some may fail with an `OSError`. This PR adds some code to handle instances where an OSError would be raised.

I've tested the package changes with a mock flow/fake data; an example log can be [found here.](https://app.prefect.cloud/account/86eb4016-3bda-40df-a926-a5da355f8393/workspace/5c4b372e-3f1b-4fed-a973-09381e72d9e2/flow-runs/flow-run/0d43e708-f186-4102-bd7e-0fdcdd29abef)

<details>
<summary>The flow code for this log can be viewed here.</summary>
<br>

Maybe not the most elegant example, but hopefully realistic enough to elicit the error and demonstrate success (following the changes in this PR). Basic idea is to mock a flow that has 9+ files that need to be written to a directory that may or may not already exist.

```python
"""Testing changes to UCB Prefect Tools sftp_put"""

import os
import pandas as pd
import time

from prefect import task, flow, get_run_logger
from prefect.blocks.system import JSON

from ucb_prefect_tools import util, object_storage
from ucb_prefect_tools.object_storage import _make_ssh_key, _load_known_hosts, _sftp_connection

from paramiko import SSHClient


@task
def sftp_rmdir(dir_path: str, connection_info: dict) -> None:
    """Removes a directory if it exists.
    dir_path must exist and be empty, otherwise an error will be raised.
    """

    get_run_logger().info(
        "SFTP: removing directory %s on %s",
        dir_path,
        connection_info["hostname"]
    )

    conn_info = connection_info.copy()
    del conn_info["system_type"]

    _make_ssh_key(conn_info)
    ssh = SSHClient()
    _load_known_hosts(ssh, conn_info)
    with _sftp_connection(ssh, conn_info) as sftp:
        sftp.rmdir(dir_path)


@task
def add_delay():
    time.sleep(30)
    return True


@task
def get_config(env: str = "dev") -> dict:
    """Configurations for the flow"""

    config = {}

    if env == "dev":
        config["sink_storage"] = JSON.load("ds-file-delivery-dev-connection").value
        config["sink_dir"] = "test/ucbde_245"
        config["sink_filepath"] = "test/ucbde_245/test_file"
    else:
        raise ValueError(f"{env} is not a recognized value for env param")

    return util.reveal_secrets(config)


@flow
def main_flow(env: str = "dev"):
    """Main flow docstring"""

    with util.limit_concurrency(max_tasks=10):
        config = get_config(env)

        my_data = pd.DataFrame({"id": [1, 2, 3], "x": [33, 8, 12]})

        filenames = [config["sink_filepath"] + f"_{i}.csv" for i in range(10)]

        for i in range(10):
            object_storage.put.with_options(retries=0).submit(
                binary_object=my_data.to_csv().encode("utf-8"),
                object_name=filenames[i],
                connection_info=config["sink_storage"],
            )
        
        done = add_delay()

        if done:
            for i in range(10):
                object_storage.remove.with_options(retries=0).submit(
                    object_name=filenames[i],
                    connection_info=config["sink_storage"],
                )

            add_delay()
            sftp_rmdir(config["sink_dir"], config["sink_storage"])


if __name__ == "__main__":
    util.run_flow_command_line_interface(
        flow_filename=os.path.basename(__file__), flow_function_name="main_flow"
    )
```

</details>

# Deployment

- Will require the team to reinstall the package
- Remove the unneeded dev deployment used for testing