### PR TITLE
UCBDE-93 Upgrade to oracledb

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ucb_prefect_tools
-version = 1.1.2
+version = 1.1.3
 author = James Ashby
 author_email = james.ashby@colorado.edu
 description = Tasks and tools for implementing Prefect data flows
@@ -14,18 +14,18 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires =
+    boto3
+    gitpython
+    minio
+    oracledb
+    pandas
+    paramiko
     prefect >= 2.0
+    psycopg2-binary
+    pyarrow
+    pyodbc
+    pysmb
     pytz
     s3fs
-    cx_Oracle
-    pandas
-    pyarrow
-    minio
-    paramiko
-    gitpython
-    boto3
-    psycopg2-binary
-    pysmb
-    pyodbc


### PR DESCRIPTION
I ran into some hiccups with getting the new dsn for edb test and prod (which allows for failing over from COMP to SPSC) to work with cx_Oracle, so I figured I'd jump the gun and move us to the much neater, and M1-compatible, oracledb package. Turns out this is a simple change: I tested all the oracle features in the database package and I think we're good to go here.