### PR TITLE
Rest exceptions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ucb_prefect_tools
-version = 1.1.5
+version = 1.2.0
 author = James Ashby
 author_email = james.ashby@colorado.edu
 description = Tasks and tools for implementing Prefect data flows

--- a/ucb_prefect_tools/rest.py
+++ b/ucb_prefect_tools/rest.py
@@ -557,8 +557,9 @@ def _send_modify_requests(
                     count += 1
                     if count % 1000 == 0:
                         get_run_logger().info(
-                            "Received %s results out of {len(endpoints)} so far...",
+                            "Received %s results out of %s so far...",
                             count,
+                            len(endpoints),
                         )
                 except StopIteration:
                     break

--- a/ucb_prefect_tools/rest.py
+++ b/ucb_prefect_tools/rest.py
@@ -110,7 +110,7 @@ def get_many(
     params_list: list[dict] = None,
     next_page_getter: Callable = None,
     to_dataframe: bool = False,
-    on_error: Literal("raise", "catch") = "raise",
+    on_error: Literal["raise", "catch"] = "raise",
     num_workers: int = 1,
 ) -> list:
     """Sends many GET requests defined by a list of endpoints and a corresponding list of params


### PR DESCRIPTION
This introduces an improved way of handling exceptions in the rest.get_many task. Instead of simply ignoring certain codes, you can specify that any exceptions should be returned, which allows you to handle them however you want. I even included example code in the docstring. This is a breaking change, but it does only impact the canvas_notifications flow, which I am opening another PR for. Originally I thought I needed this for the monitoring/flows.py flow, but it turns out I did all this work for nothing. Oh well! Still a nice improvement that may be useful in the future. Tested this with the canvas_notifications branch and had no issues.