### PR TITLE
UCBDE-58 Use KubernetesAgent for deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To deploy a flow this way, you must have Git and Docker installed and you must b
 
 Within the Git repo, the `./flows` folder should contain flow definitions, with one Python file per flow. This folder can also contain additional files to be referenced by your flows, such as SQL files for longer queries. When any flow is deployed, this entire folder is copied into the flow storage for that deployment, minus anything excluded by the `.prefectignore` file.
 
-Deployments created this way use Docker infrastructure and the flow storage defined by the `ds-flow-storage` JSON block in Prefect Cloud. The Docker registry, flow storage block name, and other settings can be overridden after importing the util package.
+Deployments created this way use KubernetesJob infrastructure and the flow storage defined by the `ds-flow-storage` JSON block in Prefect Cloud. The Docker registry, flow storage block name, and other settings can be overridden after importing the util package.
 
 ## Images for deployed flows
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can also add `@tag` to get a specific version
 
 In addition to providing Prefect tasks for common I/O operations, the Prefect Tools package also simplifies the deployment of Prefect flows with the `util.run_flow_command_line_interface` function. If your flow file is set up to automatically invoke the `util.run_flow_command_line_interface` function from the command line, you can deploy the flow like this: `python3 flows/my_flow.py deploy`.
 
-To deploy a flow this way, you must have Git and Docker installed and you must be authenticated to Prefect Cloud via your Terminal. You will need to be at the root of a Git repository, and your active branch will determine how the flow is deployed. If you are on the main branch, the flow will be deployed with the `main` label which indicates a scheduled production flow. If you are on a non-main branch, the flow will be deployed with the `dev` label instead.
+To deploy a flow this way, you must have Git installed and you must be authenticated to Prefect Cloud via your Terminal. You will need to be at the root of a Git repository, and your active branch will determine how the flow is deployed. If you are on the main branch, the flow will be deployed with the `main` label which indicates a scheduled production flow. If you are on a non-main branch, the flow will be deployed with the `dev` label instead.
 
 Within the Git repo, the `./flows` folder should contain flow definitions, with one Python file per flow. This folder can also contain additional files to be referenced by your flows, such as SQL files for longer queries. When any flow is deployed, this entire folder is copied into the flow storage for that deployment, minus anything excluded by the `.prefectignore` file.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ucb_prefect_tools
-version = v3.0.0
+version = 3.0.0
 author = James Ashby
 author_email = james.ashby@colorado.edu
 description = Tasks and tools for implementing Prefect data flows

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ucb_prefect_tools
-version = 1.0.0
+version = v3.0.0
 author = James Ashby
 author_email = james.ashby@colorado.edu
 description = Tasks and tools for implementing Prefect data flows

--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -30,6 +30,10 @@ DOCKER_REGISTRY = "oit-data-services-docker-local.artifactory.colorado.edu"
 LOCAL_FLOW_FOLDER = "flows"
 FLOW_STORAGE_CONNECTION_BLOCK = "ds-flow-storage"
 REPO_PREFIX = "oit-ds-flows-"
+POD_SIZES = {
+    "small": {"memory": "1Gi", "cpu": "250m"},
+    "large": {"memory": "10Gi", "cpu": "500m"},
+}
 
 # Timezone for `now` function
 TIMEZONE = "America/Denver"
@@ -185,7 +189,7 @@ def _deploy(flow_filename, flow_function_name, image_name, image_branch):
 
         # Parse flow docstring
         # This dict relates docstring fields with validation criteria
-        docstring_fields = {"size": lambda x: x in ["small", "large"]}
+        docstring_fields = {"size": lambda x: x in POD_SIZES}
         metadata = _parse_docstring_fields(flow, docstring_fields)
 
         # Now we can setup infrastructure and deploy the flow
@@ -254,12 +258,6 @@ def _get_repo_info():
 
 
 def _get_flow_infrastructure(label, image_uri, flow_size):
-    # Determine Kubernetes limits
-    limits = {
-        "small": {"memory": "1Gi", "cpu": "250m"},
-        "large": {"memory": "10Gi", "cpu": "500m"},
-    }
-
     # Create Kubernetes infrastructure
     return KubernetesJob(
         image=image_uri,
@@ -281,7 +279,7 @@ def _get_flow_infrastructure(label, image_uri, flow_size):
                 "op": "add",
                 "path": "/spec/template/spec/containers/0/resources",
                 "value": {
-                    "limits": limits[flow_size],
+                    "limits": POD_SIZES[flow_size],
                 },
             },
             {

--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -194,7 +194,6 @@ def _deploy(flow_filename, flow_function_name, options):
             image_pull_policy="Always",
             finished_job_ttl=120,
             namespace=f"oit-eds-prefect-{label}",
-            command="cd ~ && python -m prefect.engine",
             customizations=[
                 {
                     "op": "add",

--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -171,7 +171,7 @@ def _deploy(flow_filename, flow_function_name, options):
         label = "main"
         storage_path = f"main/{repo_name}/"
     else:
-        label = "kubernetes"
+        label = "dev"
         storage_path = f"dev/{repo_name}/{branch_name}/"
 
     # Change into the flows folder and change back when done
@@ -193,7 +193,7 @@ def _deploy(flow_filename, flow_function_name, options):
             image=image_uri,
             image_pull_policy="Always",
             finished_job_ttl=120,
-            namespace="oit-eds-etl-test",
+            namespace=f"oit-eds-prefect-{label}",
             customizations=[
                 {
                     "op": "add",
@@ -243,6 +243,7 @@ def _deploy(flow_filename, flow_function_name, options):
             name=f"{repo_short_name} | {branch_name} | {module_name}",
             tags=[label],
             work_queue_name=label,
+            work_pool_name="open-shift",
             infrastructure=k8s_job,
             storage=storage,
             apply=True,

--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -192,6 +192,7 @@ def _deploy(flow_filename, flow_function_name, options):
         k8s_job = KubernetesJob(
             image=image_uri,
             image_pull_policy="Always",
+            finished_job_ttl=120,
             namespace="oit-eds-etl-test",
             customizations=[
                 {
@@ -203,6 +204,16 @@ def _deploy(flow_filename, flow_function_name, options):
                     "op": "add",
                     "path": "/spec/template/spec/imagePullSecrets/0",
                     "value": {"name": "artifactory-secret"},
+                },
+                {
+                    "op": "add",
+                    "path": "/spec/template/spec/containers/0/securityContext",
+                    "value": {"runAsUser": 1001040000},
+                },
+                {
+                    "op": "add",
+                    "path": "/spec/template/spec/securityContext",
+                    "value": {"fsGroup": 1001040000},
                 },
             ],
         )

--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -194,6 +194,7 @@ def _deploy(flow_filename, flow_function_name, options):
             image_pull_policy="Always",
             finished_job_ttl=120,
             namespace=f"oit-eds-prefect-{label}",
+            command="cd ~ && python -m prefect.engine",
             customizations=[
                 {
                     "op": "add",
@@ -203,17 +204,7 @@ def _deploy(flow_filename, flow_function_name, options):
                 {
                     "op": "add",
                     "path": "/spec/template/spec/imagePullSecrets/0",
-                    "value": {"name": "artifactory-secret"},
-                },
-                {
-                    "op": "add",
-                    "path": "/spec/template/spec/containers/0/securityContext",
-                    "value": {"runAsUser": 1001040000},
-                },
-                {
-                    "op": "add",
-                    "path": "/spec/template/spec/securityContext",
-                    "value": {"fsGroup": 1001040000},
+                    "value": {"name": "registry-secret"},
                 },
             ],
         )

--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -16,9 +16,8 @@ from contextlib import contextmanager
 import asyncio
 import uuid
 
-from prefect import task, get_run_logger, tags, context
+from prefect import task, get_run_logger, tags, context, deployments, settings
 from prefect.utilities.filesystem import create_default_ignore_file
-from prefect.deployments import Deployment
 from prefect.filesystems import RemoteFileSystem
 from prefect.blocks.system import Secret, JSON
 from prefect.infrastructure import KubernetesJob
@@ -126,20 +125,44 @@ def run_flow_command_line_interface(flow_filename, flow_function_name, args=None
 
     if args is None:
         args = sys.argv[1:]
-    command = args[0]
-    options = args[1:]
-    if command == "deploy":
-        _deploy(flow_filename, flow_function_name, options)
-    else:
-        raise ValueError(f"Command {command} is not implemented")
-
-
-def _deploy(flow_filename, flow_function_name, options):
-    # Parse options and check file locations
     parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=["deploy", "run"])
     parser.add_argument("--image-name", type=str, default="oit-ds-prefect-default")
     parser.add_argument("--image-branch", type=str, default="main")
-    args = parser.parse_args(options)
+    parsed_args = parser.parse_args(args)
+    if parsed_args.command == "deploy":
+        _deploy(
+            flow_filename,
+            flow_function_name,
+            parsed_args.image_name,
+            parsed_args.image_branch,
+        )
+    if parsed_args.command == "run":
+        if git.Repo().active_branch.name == "main":
+            raise RuntimeError('Command "run" not allowed from main branch')
+        deployment_id = _deploy(
+            flow_filename,
+            flow_function_name,
+            parsed_args.image_name,
+            parsed_args.image_branch,
+        )
+        print("Running deployment...")
+        flow_run = deployments.run_deployment(deployment_id)
+        print(
+            f'Flow run "{flow_run.name}" finished with state {flow_run.state_name}: '
+            f"{settings.PREFECT_UI_URL.value()}/flow-runs/flow-run/{flow_run.id}"
+        )
+        asyncio.run(_delete_deployment(deployment_id))
+        print("Deleted deployment")
+
+
+async def _delete_deployment(deployment_id):
+    async with get_client() as client:
+        await client.delete_deployment(deployment_id)
+
+
+def _deploy(flow_filename, flow_function_name, image_name, image_branch):
+    # Check file locations
     if create_default_ignore_file(LOCAL_FLOW_FOLDER):
         print("Created default .prefectignore file")
     flow_filename = os.path.basename(flow_filename)
@@ -148,7 +171,65 @@ def _deploy(flow_filename, flow_function_name, options):
             f"File {flow_filename} not found in the {LOCAL_FLOW_FOLDER} folder"
         )
 
-    # Get git repo information and validate state
+    # Get repo info then temporarily switch into flows folder to make importing easier
+    label, repo_name, branch_name = _get_repo_info()
+    with _ChangeDir(LOCAL_FLOW_FOLDER):
+
+        # Import the module and flow
+        module_name = os.path.splitext(flow_filename)[0]
+        try:
+            flow = getattr(sys.modules["__main__"], flow_function_name)
+        except KeyError:
+            module = importlib.import_module(module_name)
+            flow = getattr(module, flow_function_name)
+
+        # Parse flow docstring
+        # This dict relates docstring fields with validation criteria
+        docstring_fields = {"size": lambda x: x in ["small", "large"]}
+        metadata = _parse_docstring_fields(flow, docstring_fields)
+
+        # Now we can setup infrastructure and deploy the flow
+        image_uri = f"{DOCKER_REGISTRY}/{image_name}:{image_branch}"
+        flow.name = f"{repo_name} | {module_name}"
+        deployment = deployments.Deployment.build_from_flow(
+            flow=flow,
+            name=f"{repo_name} | {branch_name} | {module_name}",
+            tags=[label, metadata["size"]],
+            work_queue_name=f"{label}-{metadata['size']}",
+            work_pool_name="open-shift",
+            infrastructure=_get_flow_infrastructure(label, image_uri, metadata["size"]),
+            storage=_get_flow_storage(),
+            # Path must end in slash!
+            path=(
+                f"main/{repo_name}/"
+                if label == "main"
+                else f"{label}/{repo_name}/{branch_name}/"
+            ),
+        )
+        deployment_id = deployment.apply(upload=True)
+        print(
+            f"Deployed {deployment.name} using docker image {image_uri}: "
+            f"{settings.PREFECT_UI_URL.value()}/deployments/deployment/{deployment_id}"
+        )
+        return deployment_id
+
+
+class _ChangeDir:
+    """Allows temporary directory change"""
+
+    def __init__(self, path):
+        self.path = path
+        self.saved_path = None
+
+    def __enter__(self):
+        self.saved_path = os.getcwd()
+        os.chdir(self.path)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        os.chdir(self.saved_path)
+
+
+def _get_repo_info():
     repo = git.Repo()
     repo_name = os.path.basename(repo.working_dir)
     repo_short_name = repo_name.removeprefix(REPO_PREFIX)
@@ -167,106 +248,91 @@ def _deploy(flow_filename, flow_function_name, options):
                 "Commit or discard changes to continue."
             )
         label = "main"
-        storage_path = f"main/{repo_name}/"
     else:
         label = "dev"
-        storage_path = f"dev/{repo_name}/{branch_name}/"
+    return label, repo_short_name, branch_name
 
-    # Change into the flows folder and change back when done
-    cwd = os.getcwd()
-    os.chdir(LOCAL_FLOW_FOLDER)
-    try:
 
-        # Import the module and flow
-        module_name = os.path.splitext(flow_filename)[0]
-        try:
-            flow_function = getattr(sys.modules["__main__"], flow_function_name)
-        except KeyError:
-            module = importlib.import_module(module_name)
-            flow_function = getattr(module, flow_function_name)
-        # Parse flow docstring
-        # This dict relates docstring fields with validation criteria
-        docstring_fields = {"size": lambda x: x in ["small", "large"]}
-        metadata = _parse_docstring_fields(flow_function, docstring_fields)
+def _get_flow_infrastructure(label, image_uri, flow_size):
+    # Determine Kubernetes limits
+    limits = {
+        "small": {"memory": "1Gi", "cpu": "250m"},
+        "large": {"memory": "10Gi", "cpu": "500m"},
+    }
 
-        # Determine Kubernetes limits
-        limits = {
-            "small": {"memory": "1Gi", "cpu": "250m"},
-            "large": {"memory": "10Gi", "cpu": "500m"},
-        }
+    # Create Kubernetes infrastructure
+    return KubernetesJob(
+        image=image_uri,
+        image_pull_policy="Always",
+        finished_job_ttl=1200,
+        namespace=f"oit-eds-prefect-{label}",
+        customizations=[
+            {
+                "op": "add",
+                "path": "/spec/template/spec/imagePullSecrets",
+                "value": [],
+            },
+            {
+                "op": "add",
+                "path": "/spec/template/spec/imagePullSecrets/0",
+                "value": {"name": "registry-secret"},
+            },
+            {
+                "op": "add",
+                "path": "/spec/template/spec/containers/0/resources",
+                "value": {
+                    "limits": limits[flow_size],
+                },
+            },
+            {
+                "op": "add",
+                "path": "/spec/backoffLimit",
+                "value": 0,
+            },
+        ],
+    )
 
-        # Create Kubernetes infrastructure
-        image_uri = f"{DOCKER_REGISTRY}/{args.image_name}:{args.image_branch}"
-        k8s_job = KubernetesJob(
-            image=image_uri,
-            image_pull_policy="Always",
-            finished_job_ttl=120,
-            namespace=f"oit-eds-prefect-{label}",
-            customizations=[
-                {
-                    "op": "add",
-                    "path": "/spec/template/spec/imagePullSecrets",
-                    "value": [],
-                },
-                {
-                    "op": "add",
-                    "path": "/spec/template/spec/imagePullSecrets/0",
-                    "value": {"name": "registry-secret"},
-                },
-                {
-                    "op": "add",
-                    "path": "/spec/template/spec/containers/0/resources",
-                    "value": {
-                        "limits": limits[metadata["size"]],
-                    },
-                },
-                {
-                    "op": "add",
-                    "path": "/spec/backoffLimit",
-                    "value": 0,
-                },
-            ],
+
+def _get_flow_storage():
+    storage_conn = reveal_secrets(JSON.load(FLOW_STORAGE_CONNECTION_BLOCK).value)
+    if storage_conn["system_type"] == "minio":
+        endpoint_url = storage_conn["endpoint"]
+        if not endpoint_url.startswith("https://"):
+            endpoint_url = "https://" + endpoint_url
+        return RemoteFileSystem(
+            basepath=f's3://{storage_conn["bucket"]}/',
+            settings={
+                "key": storage_conn["access_key"],
+                "secret": storage_conn["secret_key"],
+                "client_kwargs": {"endpoint_url": endpoint_url},
+            },
         )
+    raise ValueError(
+        f'Flow storage connection system type {storage_conn["system_type"]} not supported'
+    )
 
-        # Create flow storage infrastructure
-        storage_conn = reveal_secrets(JSON.load(FLOW_STORAGE_CONNECTION_BLOCK).value)
-        if storage_conn["system_type"] == "minio":
-            endpoint_url = storage_conn["endpoint"]
-            if not endpoint_url.startswith("https://"):
-                endpoint_url = "https://" + endpoint_url
-            storage = RemoteFileSystem(
-                basepath=f's3://{storage_conn["bucket"]}/',
-                settings={
-                    "key": storage_conn["access_key"],
-                    "secret": storage_conn["secret_key"],
-                    "client_kwargs": {"endpoint_url": endpoint_url},
-                },
-            )
-        else:
-            raise ValueError(
-                f'Flow storage connection system type {storage_conn["system_type"]} not supported'
-            )
 
-        # Deploy flow
-        deployment = Deployment.build_from_flow(
-            flow=flow_function,
-            name=f"{repo_short_name} | {branch_name} | {module_name}",
-            tags=[label, metadata["size"]],
-            work_queue_name=f"{label}-{metadata['size']}",
-            work_pool_name="open-shift",
-            infrastructure=k8s_job,
-            storage=storage,
-            apply=True,
-            path=storage_path,
-        )
-        print(f"Deployed {deployment.name} using docker image {image_uri}")
-
-    finally:
-        try:
-            os.chdir(cwd)
-        # pylint:disable=broad-except
-        except Exception:
-            pass
+def _parse_docstring_fields(function, fields):
+    docstring = inspect.getdoc(function)
+    result = {i: None for i in fields.keys()}
+    if docstring:
+        for field, validator in fields.items():
+            pattern = rf":{field}:\s*(\w+)"
+            matches = re.findall(pattern, docstring)
+            # Check just one value found and that it is a valid value
+            if len(matches) == 1:
+                value = matches[0]
+                if not validator(value):
+                    raise ValueError(
+                        f"Value '{value}' of field '{field}' in flow docstring is not allowed"
+                    )
+                result[field] = value
+            else:
+                raise ValueError(
+                    f"Found {len(matches)} entries for '{field}' in flow docstring; "
+                    "must have exactly 1"
+                )
+    return result
 
 
 def reveal_secrets(json_obj) -> dict:
@@ -307,25 +373,3 @@ def sizeof_fmt(num: int) -> str:
             return f"{num:3.1f} {unit}"
         num /= 1024.0
     return f"{num:.1f} PB"
-
-
-def _parse_docstring_fields(function, fields):
-    docstring = inspect.getdoc(function)
-    result = {i: None for i in fields.keys()}
-    if docstring:
-        for field, validator in fields.items():
-            pattern = rf":{field}:\s*(\w+)"
-            matches = re.findall(pattern, docstring)
-            # Check just one value found and that it is a valid value
-            if len(matches) == 1:
-                value = matches[0]
-                if not validator(value):
-                    raise ValueError(
-                        f"Value '{value}' of {field} in flow docstring is not allowed"
-                    )
-                result[field] = value
-            else:
-                raise ValueError(
-                    f"More than one entry found for {field} in flow docstring"
-                )
-    return result


### PR DESCRIPTION
These are the changes necessary to get our flows to run on OpenShift. Going forward, all flows will require a `:size:` label in their docstring of either "small" or "large" to determine how much resources the KubernetesJob will take up (see util._get_flow_infrastructure for specific limits). Most flows will be small, but some will need to be run as large. The Prefect open-shift work pool is set up to allow 1 large flow at a time and 4 small ones (with dev and main using separate OpenShift namespaces and separate resource pools).

Once you upgrade to this version of prefect tools, you won't be able to deploy to the Prefect VM anymore, but you can always re-install version 2.1.0 if you need to do so.

This PR also includes some quality of life improvements, like giving you the link to the deployment when you deploy a flow, and the new "run" command which will create a deployment, run the flow, then delete the deployment afterward, and give you a link to the flow run so you can see the results, all with just a single command.

See the Kubernetes configuration for the agent here: https://github.com/UCBoulder/oit-ds-apps-prefect

I still need to update our template repo and also our wiki documentation, but I'll do that probably tomorrow.