### PR TITLE
Add authentication to send_email

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ucb_prefect_tools
-version = 3.0.0
+version = 3.1.0
 author = James Ashby
 author_email = james.ashby@colorado.edu
 description = Tasks and tools for implementing Prefect data flows

--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -72,6 +72,9 @@ def send_email(
             msg.attach(obj)
 
     mailserver = smtplib.SMTP(smtp_info["host"], smtp_info["port"])
+    if "username" in smtp_info:
+        mailserver.starttls()
+        mailserver.login(smtp_info["username"], smtp_info["password"])
 
     if addressed_to:
         info = f'Sending "{subject}" email to {addressed_to}'


### PR DESCRIPTION
This will allow us to use username/password authentication for smtp which is necessary to send emails from openshift.

To deploy, we should update the smtp-connection block to use `"host": "smtp-ucb.colorado.edu", "port": 587` and the oit-ds-prefect user/password. This should work in all execution environments. 
