### PR TITLE
UCBDE-277,280 Add support for tags in flow docstring

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ucb_prefect_tools
-version = 4.0.0
+version = 4.1.0
 author = James Ashby
 author_email = james.ashby@colorado.edu
 description = Tasks and tools for implementing Prefect data flows

--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -311,7 +311,7 @@ def parse_docstring_fields(function, fields):
     result = {i: "" for i in fields.keys()}
     if docstring:
         for field, validator in fields.items():
-            pattern = re.compile(r"^\s*:tags:\s*(.*)", re.MULTILINE)
+            pattern = re.compile(rf"^\s*:{field}:\s*(.*)", re.MULTILINE)
             matches = pattern.findall(docstring)
             # Check just one value found and that it is a valid value
             if len(matches) == 1:

--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -189,7 +189,7 @@ def _deploy(flow_filename, flow_function_name, image_name, image_branch):
             flow_function = getattr(module, flow_function_name)
 
         # Parse docstring fields and action on them as appropriate
-        docstring_fields = _parse_docstring_fields(
+        docstring_fields = parse_docstring_fields(
             flow_function, {"tags": lambda x: all(i.strip() for i in x.split(","))}
         )
         # Additional tags are only included on main flows
@@ -293,7 +293,7 @@ def _get_flow_storage():
     )
 
 
-def _parse_docstring_fields(function, fields):
+def parse_docstring_fields(function, fields):
     docstring = inspect.getdoc(function)
     result = {i: "" for i in fields.keys()}
     if docstring:

--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -197,7 +197,7 @@ def _deploy(flow_filename, flow_function_name, image_name, image_branch):
         additional_tags = [i.strip() for i in docstring_fields["tags"].split(",") if i]
         if label == "main":
             flow_tags.extend(additional_tags)
-        else:
+        elif additional_tags:
             print(f"Additional tags not added to dev deployment: {additional_tags}")
 
         # Now we can setup infrastructure and deploy the flow
@@ -294,6 +294,13 @@ def _get_flow_storage():
 
 
 def parse_docstring_fields(function, fields):
+    """Takes a function and a dictionary of field names mapped to functions that take field values
+    and return False if the field values are not valid. Looks at the function docstring and extracts
+    any Sphinx-style field labels (like `:tags: crm-ops`) from the docstring. If any key in `fields`
+    is not present in the docstring, its value is set to ''. Otherwise, values (like 'crm-ops')
+    are passed to the corresponding function given in the `fields` dict to ensure they are valid.
+    Finally, we return a dictionary mapping field keys to values from the actual docstring."""
+
     docstring = inspect.getdoc(function)
     result = {i: "" for i in fields.keys()}
     if docstring:

--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -190,7 +190,10 @@ def _deploy(flow_filename, flow_function_name, image_name, image_branch):
 
         # Parse docstring fields and action on them as appropriate
         docstring_fields = parse_docstring_fields(
-            flow_function, {"tags": lambda x: all(i.strip() for i in x.split(","))}
+            # Validate that "tags" is a list of 1 or more non-blank, comma-separated strings
+            # e.g. "tag1,, tag2" would fail due to a blank string in the middle slot
+            flow_function,
+            {"tags": lambda x: all(i.strip() for i in x.split(","))},
         )
         # Additional tags are only included on main flows
         flow_tags = [label]
@@ -299,7 +302,10 @@ def parse_docstring_fields(function, fields):
     any Sphinx-style field labels (like `:tags: crm-ops`) from the docstring. If any key in `fields`
     is not present in the docstring, its value is set to ''. Otherwise, values (like 'crm-ops')
     are passed to the corresponding function given in the `fields` dict to ensure they are valid.
-    Finally, we return a dictionary mapping field keys to values from the actual docstring."""
+    Finally, we return a dictionary mapping field keys to values from the actual docstring.
+
+    Raises ValueError if a label (e.g. `:tags:`) appears more than once in the docstring.
+    """
 
     docstring = inspect.getdoc(function)
     result = {i: "" for i in fields.keys()}


### PR DESCRIPTION
Incorporating optional additional tags in a flow's docstring allows us to address both https://cu-oda.atlassian.net/browse/UCBDE-280 and https://cu-oda.atlassian.net/browse/UCBDE-277. Crucially, this allows us to preserve the crm-ops and lms-leads tags which are necessary to trigger automated failure emails. See this for example usage: https://github.com/UCBoulder/oit-ds-flows-ata/blob/e57758bd262bf62a7496dc04d96f011724e91ae9/flows/canvas_data_monitor.py#L55