### PR TITLE
Fix issues with inserting or updating Oracle values

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ucb_prefect_tools
-version = 5.4.0
+version = 5.4.1
 author = James Ashby
 author_email = james.ashby@colorado.edu
 description = Tasks and tools for implementing Prefect data flows
@@ -20,10 +20,10 @@ install_requires =
     gitpython
     minio
     mysql-connector-python
-    oracledb
+    oracledb < 2.0
     pandas < 2.0
     paramiko
-    prefect >= 2.0
+    prefect
     psycopg2-binary
     pyarrow
     pyodbc

--- a/ucb_prefect_tools/database.py
+++ b/ucb_prefect_tools/database.py
@@ -229,15 +229,15 @@ def _oracle_host(dsn_string):
 
 
 def _oracle_cast(value):
+    # Convert Na-like objects to None
+    if pd.isnull(value):
+        return None
+
     # Convert date-like objects to strings in the Oracle format
     if isinstance(value, (datetime.datetime, pd.Timestamp)):
         return value.strftime("%Y-%m-%d %H:%M:%S")
     if isinstance(value, datetime.date):
         return value.strftime("%Y-%m-%d 00:00:00")
-
-    # Convert Na-like objects to None
-    if pd.isnull(value):
-        return None
 
     # Return everything else as a string
     return str(value)
@@ -362,6 +362,10 @@ def oracle_insert(
             get_run_logger().info(
                 "Oracle: Inserting into %s on %s", table_identifier, host
             )
+            # Set ISO date format for insertion
+            cursor.execute(
+                "ALTER SESSION SET NLS_DATE_FORMAT = 'YYYY-MM-DD HH24:MI:SS'"
+            )
             # Insert records in batches
             for start in range(0, len(records), batch_size):
                 to_insert = records[start : start + batch_size]
@@ -450,6 +454,10 @@ def oracle_update(
         try:
             get_run_logger().info(
                 "Oracle: Updating data in %s on %s", table_identifier, host
+            )
+            # Set ISO date format for insertion
+            cursor.execute(
+                "ALTER SESSION SET NLS_DATE_FORMAT = 'YYYY-MM-DD HH24:MI:SS'"
             )
             # Update records in batches
             for start in range(0, len(records), batch_size):

--- a/ucb_prefect_tools/database.py
+++ b/ucb_prefect_tools/database.py
@@ -362,9 +362,12 @@ def oracle_insert(
             get_run_logger().info(
                 "Oracle: Inserting into %s on %s", table_identifier, host
             )
-            # Set ISO date format for insertion
+            # Set ISO date/timestamp format for insertion
             cursor.execute(
-                "ALTER SESSION SET NLS_DATE_FORMAT = 'YYYY-MM-DD HH24:MI:SS'"
+                """BEGIN
+    EXECUTE IMMEDIATE 'ALTER SESSION SET NLS_DATE_FORMAT = ''YYYY-MM-DD HH24:MI:SS''';
+    EXECUTE IMMEDIATE 'ALTER SESSION SET NLS_TIMESTAMP_FORMAT = ''YYYY-MM-DD HH24:MI:SS''';
+END;"""
             )
             # Insert records in batches
             for start in range(0, len(records), batch_size):
@@ -455,9 +458,12 @@ def oracle_update(
             get_run_logger().info(
                 "Oracle: Updating data in %s on %s", table_identifier, host
             )
-            # Set ISO date format for insertion
+            # Set ISO date/timestamp format for insertion
             cursor.execute(
-                "ALTER SESSION SET NLS_DATE_FORMAT = 'YYYY-MM-DD HH24:MI:SS'"
+                """BEGIN
+    EXECUTE IMMEDIATE 'ALTER SESSION SET NLS_DATE_FORMAT = ''YYYY-MM-DD HH24:MI:SS''';
+    EXECUTE IMMEDIATE 'ALTER SESSION SET NLS_TIMESTAMP_FORMAT = ''YYYY-MM-DD HH24:MI:SS''';
+END;"""
             )
             # Update records in batches
             for start in range(0, len(records), batch_size):


### PR DESCRIPTION
We've been seeing issues with inserting numerical or date-like values into Oracle databases in which, for some unknown reason, Oracle expects these values to be in a string format. This fixes that issue by converting all types to strings, and has been tested with several flows.