### PR TITLE
UCBDE-662 Add support for Snowflake databases

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,3 +30,4 @@ install_requires =
     pysmb
     pytz
     s3fs
+    snowflake-connector-python

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ucb_prefect_tools
-version = 5.5.0
+version = 5.7.0
 author = James Ashby
 author_email = james.ashby@colorado.edu
 description = Tasks and tools for implementing Prefect data flows

--- a/ucb_prefect_tools/database.py
+++ b/ucb_prefect_tools/database.py
@@ -631,6 +631,7 @@ def snowflake_insert(
             FILE_FORMAT = (
                 TYPE = 'CSV'
                 PARSE_HEADER = TRUE
+                MATCH_BY_COLUMN_NAME = TRUE
                 FIELD_OPTIONALLY_ENCLOSED_BY = '"'
                 ESCAPE_UNENCLOSED_FIELD = NONE
                 EMPTY_FIELD_AS_NULL = FALSE

--- a/ucb_prefect_tools/database.py
+++ b/ucb_prefect_tools/database.py
@@ -27,7 +27,7 @@ import pyodbc
 from mysql import connector as mysql_connector
 from prefect import task, get_run_logger
 import pandas as pd
-import snowflake
+from snowflake import connector as snowflake_connector
 
 from . import util
 
@@ -68,7 +68,7 @@ def sql_extract(
         postgre=get_sql_extract("Postgre", psycopg2.connect),
         odbc=get_sql_extract("ODBC", odbc_connect),
         mysql=get_sql_extract("MySQL", mysql_connector.connect),
-        snowflake=get_sql_extract("Snowflake", snowflake.connector.connect),
+        snowflake=get_sql_extract("Snowflake", snowflake_connector.connect),
     )
     dataframe = function(
         sql_query, info, query_params, lob_columns, chunks_prefix, chunksize
@@ -152,7 +152,7 @@ def update(
         postgre=get_update("Postgre", psycopg2.connect),
         odbc=get_update("ODBC", odbc_connect),
         mysql=get_update("MySQL", mysql_connector.connect),
-        snowflake=get_update("Snowflake", snowflake.connector.connect),
+        snowflake=get_update("Snowflake", snowflake_connector.connect),
     )
     return function(
         dataframe,
@@ -177,7 +177,7 @@ def execute_sql(sql_statement: str, connection_info: dict, query_params=None):
         postgre=get_execute_sql("Postgre", psycopg2.connect),
         odbc=get_execute_sql("ODBC", odbc_connect),
         mysql=get_execute_sql("MySQL", mysql_connector.connect),
-        snowflake=get_execute_sql("Snowflake", snowflake.connector.connect),
+        snowflake=get_execute_sql("Snowflake", snowflake_connector.connect),
     )
     return function(sql_statement, info, query_params)
 
@@ -591,7 +591,7 @@ def snowflake_insert(
 
     # With autocommit as False, all DML in the context manager should execute as a single
     # transaction and roll back upon any failure
-    with snowflake.connector.connect(**connection_info, autocommit=False) as conn:
+    with snowflake_connector.connect(**connection_info, autocommit=False) as conn:
         host = _hostname(connection_info, "Snowflake")
         cursor = conn.cursor()
 

--- a/ucb_prefect_tools/database.py
+++ b/ucb_prefect_tools/database.py
@@ -630,13 +630,12 @@ def snowflake_insert(
             COPY INTO {table}
             FILE_FORMAT = (
                 TYPE = 'CSV'
-                PARSE_HEADER = TRUE
-                MATCH_BY_COLUMN_NAME = TRUE
                 FIELD_OPTIONALLY_ENCLOSED_BY = '"'
                 ESCAPE_UNENCLOSED_FIELD = NONE
                 EMPTY_FIELD_AS_NULL = FALSE
                 NULL_IF = ('#N/A')
             )
+            MATCH_BY_COLUMN_NAME = 'CASE_INSENSITIVE'
             PURGE = TRUE"""
         )
 

--- a/ucb_prefect_tools/database.py
+++ b/ucb_prefect_tools/database.py
@@ -863,10 +863,13 @@ def get_update(system_type, connection_func):
         else:
             set_list = [f"{i} = %({i})s" for i in set_columns]
             match_list = [f"{i} = %({i})s" for i in match_on]
+            get_run_logger().warning(dataframe.to_dict("records"))
             records = [
                 {k: _cast(v) for k, v in i.items()}
                 for i in dataframe.to_dict("records")
             ]
+            get_run_logger().warning(records)
+            get_run_logger().warning(type(records[0]['grade_at']))
         update_sql = (
             f'UPDATE {table_identifier} SET {", ".join(set_list)} '
             + f'WHERE {" AND ".join(match_list)}'

--- a/ucb_prefect_tools/database.py
+++ b/ucb_prefect_tools/database.py
@@ -630,6 +630,7 @@ def snowflake_insert(
             COPY INTO {table}
             FILE_FORMAT = (
                 TYPE = 'CSV'
+                PARSE_HEADER = TRUE
                 FIELD_OPTIONALLY_ENCLOSED_BY = '"'
                 ESCAPE_UNENCLOSED_FIELD = NONE
                 EMPTY_FIELD_AS_NULL = FALSE

--- a/ucb_prefect_tools/database.py
+++ b/ucb_prefect_tools/database.py
@@ -863,13 +863,10 @@ def get_update(system_type, connection_func):
         else:
             set_list = [f"{i} = %({i})s" for i in set_columns]
             match_list = [f"{i} = %({i})s" for i in match_on]
-            get_run_logger().warning(dataframe.to_dict("records"))
             records = [
                 {k: _cast(v) for k, v in i.items()}
                 for i in dataframe.to_dict("records")
             ]
-            get_run_logger().warning(records)
-            get_run_logger().warning(type(records[0]['grade_at']))
         update_sql = (
             f'UPDATE {table_identifier} SET {", ".join(set_list)} '
             + f'WHERE {" AND ".join(match_list)}'

--- a/ucb_prefect_tools/database.py
+++ b/ucb_prefect_tools/database.py
@@ -631,7 +631,7 @@ def snowflake_insert(
             FILE_FORMAT = (
                 TYPE = 'CSV'
                 PARSE_HEADER = TRUE
-                FIELD_OPTIONALLY_ENCLOSED_BY = "
+                FIELD_OPTIONALLY_ENCLOSED_BY = '"'
                 ESCAPE_UNENCLOSED_FIELD = NONE
                 EMPTY_FIELD_AS_NULL = FALSE
                 NULL_IF = ('#N/A')


### PR DESCRIPTION
For the most part, Snowflake connections function just like other databases that Python connects to. But the usual way of using INSERT to add data to a table is not cost effective: instead you have to upload a CSV file to the table's "stage" and then use COPY INTO to fill the data into the table. As such, this adds a custom snowflake_insert implementation for that task and otherwise relies on the generic implementations. The only other thing is that UPDATE has the same limitations, but given that we rarely use this task and so far only for tiny changes, I just added a limit to the number of allowed updates to avoid potential runaway usage. If we find we need to do big updates in the future (unlikely), we can revisit this implementation.

Finally, I made some tweaks like applying the _cast function to all inserted/updated values (i.e. turn all values into strings for all databases). This change is necessary for Snowflake (just like it was for Oracle previously), and I searched documentation for postgres, mysql, and odbc and confirmed that all these connections also accept datetimes in ISO format. Having said that, there isn't an easy way to test inserts on these types of databases directly, but I feel like the risk for issues is low and we can always correct them if they occur.

Finally, did a little refactor to move all the hostname logic to one function, which is used to help with logging different database types.