### PR TITLE
Fix init on nonexistent archive

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ucb_prefect_tools
-version = 5.7.1
+version = 5.7.2
 author = James Ashby
 author_email = james.ashby@colorado.edu
 description = Tasks and tools for implementing Prefect data flows

--- a/ucb_prefect_tools/data_archive.py
+++ b/ucb_prefect_tools/data_archive.py
@@ -390,7 +390,11 @@ def init(archive_path: str, overwrite: bool = False) -> None:
     and a file already exists at `archive_path`, then prints the results of `info` for it instead
     of replacing it with an empty file."""
 
-    archive_df = get_data(archive_path, include_deleted=True)
+    try:
+        archive_df = get_data(archive_path, include_deleted=True)
+
+    except FileNotFoundError:
+        archive_df = pd.DataFrame()
 
     if not archive_df.empty and not overwrite:
         # If archive exists and overwrite is False, print info about the existing archive


### PR DESCRIPTION
Allows using init to create an archive when no archive at that path exists. 

Catches a FileNotFoundError on the get_data attempt and passes an empty dataframe to the rest of the function.