### PR TITLE
Switch to worker-based deployments on OpenShift

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
     pandas < 2.0
     paramiko
     prefect
+    prefect-aws
     psycopg2-binary
     pyarrow
     pyodbc

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ucb_prefect_tools
-version = 5.7.1
+version = 6.0.0
 author = James Ashby
 author_email = james.ashby@colorado.edu
 description = Tasks and tools for implementing Prefect data flows

--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -300,7 +300,7 @@ def _get_repo_info():
     # Also raise error if working tree is dirty (not counting untracked files)
     if repo.is_dirty():
         raise RuntimeError(
-            "You are attempting to deploy from `main`, but your working tree is not clean. "
+            "You are attempting to deploy using Github, but your working tree is not clean. "
             "Commit or discard changes to continue."
         )
     if branch_name == "main":

--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -247,10 +247,7 @@ def _deploy(flow_filename, flow_function_name, image_name, image_branch, label="
         elif additional_tags:
             print(f"Additional tags not added to dev deployment: {additional_tags}")
 
-        size = docstring_fields["size"]
-        if not size:
-            raise ValueError("No size specified in the docstring for this flow")
-        work_pool_name = f"k8s-{size}-{label}"
+        work_pool_name = f"k8s-{label}"
         flow_obj = flow.from_source(
             source=GitRepository(
                 url=f"https://github.com/{GITHUB_ORG}/{REPO_PREFIX}{repo_name}.git",

--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -141,7 +141,7 @@ def deployable(flow_obj):
     # Auto-generate the flow name based on the repo name (aka the cwd) and the flow file name
     flow_obj.name = (
         f"{os.path.basename(os.path.dirname(os.getcwd())).removeprefix(REPO_PREFIX)}"
-        f" | {os.path.splitext(os.path.basename(inspect.getfile(flow_obj.fn)))}"
+        f" | {os.path.splitext(os.path.basename(inspect.getfile(flow_obj.fn)))[0]}"
     )
     return flow_obj
 

--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -140,7 +140,8 @@ def deployable(flow_obj):
         )
     # Auto-generate the flow name based on the repo name (aka the cwd) and the flow file name
     flow_obj.name = (
-        f"{os.getcwd().removeprefix(REPO_PREFIX)} | {flow_obj.fn.__module__}"
+        f"{os.path.basename(os.path.dirname(os.getcwd())).removeprefix(REPO_PREFIX)}"
+        f" | {os.path.splitext(os.path.basename(inspect.getfile(flow_obj.fn)))}"
     )
     return flow_obj
 

--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -18,24 +18,22 @@ import uuid
 
 from prefect import task, get_run_logger, tags, context, deployments, settings, flow
 from prefect.utilities.filesystem import create_default_ignore_file
-from prefect.infrastructure import DockerContainer
 from prefect.blocks.system import Secret
 from prefect.client.orchestration import get_client
+from prefect.runner.storage import GitRepository
 from prefect_dask.task_runners import DaskTaskRunner
 from prefect_aws import S3Bucket
-from prefect_aws.deployments.steps import push_to_s3
 import git
 import pytz
 
 
 # Overrideable settings related to deployments
 DOCKER_REGISTRY = "oit-data-services-docker-local.artifactory.colorado.edu"
+GITHUB_ORG = "UCBoulder"
 LOCAL_FLOW_FOLDER = "flows"
 REPO_PREFIX = "oit-ds-flows-"
-# For example, dev flow code will be stored in the ds-flow-storage-dev storage block
-# and flow results will be stored in the ds-flow-storage-results storage block in Prefect Cloud
-FLOW_STORAGE_BLOCK_PREFIX = "ds-flow-storage-"
-
+GITHUB_SECRET_BLOCK = "github-pat"
+RESULT_STORAGE_BLOCK = "flow-result-storage"
 # Timezone for `now` function
 TIMEZONE = "America/Denver"
 
@@ -135,7 +133,7 @@ def deployable(flow_obj):
         flow_obj.timeout_seconds = 8 * 3600
     if flow_obj.result_storage is None:
         # Terminal slash in the path is probably non-optional
-        flow_obj.result_storage = _get_remote_storage("results")
+        flow_obj.result_storage = S3Bucket.load(RESULT_STORAGE_BLOCK)
     if flow_obj.task_runner is None:
         flow_obj.task_runner = (
             DaskTaskRunner(cluster_kwargs={"n_workers": 1, "threads_per_worker": 10}),
@@ -213,13 +211,6 @@ def _deploy(flow_filename, flow_function_name, image_name, image_branch, label="
         deployment_name = f"{repo_name} | {branch_name} | {module_name}"
     else:
         deployment_name = f"{repo_name} | {branch_name} (as {label}) | {module_name}"
-    storage_path = (
-        # Note that this is relative to whatever bucket_folder might be defined in the S3 block
-        # Path must end in slash!
-        f"{repo_name}/"
-        if label == "main"
-        else f"{repo_name}/{branch_name}/"
-    )
     image_uri = f"{DOCKER_REGISTRY}/{image_name}:{image_branch}"
     flow_name = f"{repo_name} | {module_name}"
 
@@ -249,26 +240,29 @@ def _deploy(flow_filename, flow_function_name, image_name, image_branch, label="
         elif additional_tags:
             print(f"Additional tags not added to dev deployment: {additional_tags}")
 
-        # return _deploy_to_agent(
-        #     flow_function,
-        #     image_uri,
-        #     flow_name,
-        #     deployment_name,
-        #     flow_tags,
-        #     label,
-        #     storage_path,
-        # )
-
-        return _deploy_to_worker(
-            image_uri,
-            module_name,
-            flow_function_name,
-            flow_name,
-            deployment_name,
-            flow_tags,
-            label,
-            storage_path,
+        flow_obj = flow.from_source(
+            source=GitRepository(
+                url=f"https://github.com/{GITHUB_ORG}/{REPO_PREFIX}{repo_name}.git",
+                branch=branch_name,
+                credentials={"access_token": Secret.load(GITHUB_SECRET_BLOCK)},
+            ),
+            entrypoint=f"{LOCAL_FLOW_FOLDER}/{module_name}.py:{flow_function_name}",
         )
+        flow_obj.name = flow_name
+        work_pool_name = f"k8s-{label}"
+        deployment_id = flow_obj.deploy(
+            name=deployment_name,
+            work_pool_name=work_pool_name,
+            image=image_uri,
+            build=False,
+            print_next_steps=False,
+        )
+        print(
+            f"Deployed {deployment_name}\n\tWork Pool: {work_pool_name}\n\t"
+            f"Docker image: {image_uri}\n\tTags: {flow_tags}\n\tDeployment URL: "
+            f"{settings.PREFECT_UI_URL.value()}/deployments/deployment/{deployment_id}"
+        )
+        return deployment_id
 
 
 class _ChangeDir:
@@ -291,99 +285,23 @@ def _get_repo_info():
     repo_name = os.path.basename(repo.working_dir)
     repo_short_name = repo_name.removeprefix(REPO_PREFIX)
     branch_name = repo.active_branch.name
+    # Raise error if current commit doesn't match origin commit
+    if repo.head.commit != repo.remotes.origin.fetch()[0].commit:
+        raise RuntimeError(
+            "You are attempting to deploy from `main`, but HEAD is not on the "
+            "same commit as remote `origin`. Push or pull changes to continue."
+        )
+    # Also raise error if working tree is dirty (not counting untracked files)
+    if repo.is_dirty():
+        raise RuntimeError(
+            "You are attempting to deploy from `main`, but your working tree is not clean. "
+            "Commit or discard changes to continue."
+        )
     if branch_name == "main":
-        # For main, raise error if current commit doesn't match origin commit
-        if repo.head.commit != repo.remotes.origin.fetch()[0].commit:
-            raise RuntimeError(
-                "You are attempting to deploy from `main`, but HEAD is not on the "
-                "same commit as remote `origin`. Push or pull changes to continue."
-            )
-        # For main, also raise error if working tree is dirty (not counting untracked files)
-        if repo.is_dirty():
-            raise RuntimeError(
-                "You are attempting to deploy from `main`, but your working tree is not clean. "
-                "Commit or discard changes to continue."
-            )
         label = "main"
     else:
         label = "dev"
     return label, repo_short_name, branch_name
-
-
-def _deploy_to_worker(
-    image_uri,
-    module_name,
-    flow_function_name,
-    flow_name,
-    deployment_name,
-    flow_tags,
-    label,
-    storage_path,
-):
-    # pylint:disable=too-many-arguments
-
-    # Get the storage bucket
-    bucket = _get_remote_storage(label)
-    # Now push the code to the bucket
-    # This step would need to be adjusted accordingly if not using minio storage
-    push_to_s3(
-        bucket=bucket.bucket_name,
-        folder=f"{label}/{storage_path}",
-        credentials={
-            "aws_access_key_id": bucket.credentials.minio_root_user,
-            "aws_secret_access_key": bucket.credentials.minio_root_password.get_secret_value(),
-        },
-        client_parameters=bucket.credentials.aws_client_parameters.get_params_override(),
-    )
-    bucket.bucket_folder = f"{label}/{storage_path}"
-    flow_obj = flow.from_source(bucket, f"{module_name}.py:{flow_function_name}")
-    flow_obj.name = flow_name
-    work_pool_name = f"k8s-{label}"
-    deployment = flow_obj.to_deployment(
-        name=deployment_name,
-        work_pool_name=work_pool_name,
-    )
-    # TODO: Prefect downloads the full bucket anyway based on the Prefect cloud block
-    deployment._path = f"{label}/{storage_path}"
-    deployment_id = deployment.apply(image=image_uri)
-    print(
-        f"Deployed {deployment_name}\n\tWork Pool: {work_pool_name}\n\t"
-        f"Docker image: {image_uri}\n\tTags: {flow_tags}\n\tDeployment URL: "
-        f"{settings.PREFECT_UI_URL.value()}/deployments/deployment/{deployment_id}"
-    )
-    return deployment_id
-
-
-def _deploy_to_agent(
-    flow_obj, image_uri, flow_name, deployment_name, flow_tags, label, storage_path
-):
-    # pylint:disable=too-many-arguments
-    flow_obj.name = flow_name
-    deployment = deployments.Deployment.build_from_flow(
-        flow=flow_obj,
-        name=deployment_name,
-        tags=flow_tags,
-        work_pool_name=f"{label}-agent",
-        work_queue_name=None,
-        infrastructure=DockerContainer(
-            image=image_uri,
-            image_pull_policy="ALWAYS",
-            auto_remove=True,
-        ),
-        storage=_get_remote_storage(label),
-        path=storage_path,
-    )
-    deployment_id = deployment.apply(upload=True)
-    print(
-        f"Deployed {deployment.name}\n\tWork Pool: {deployment.work_pool_name}\n\t"
-        f"Docker image: {image_uri}\n\tTags: {flow_tags}\n\tDeployment URL: "
-        f"{settings.PREFECT_UI_URL.value()}/deployments/deployment/{deployment_id}"
-    )
-    return deployment_id
-
-
-def _get_remote_storage(suffix):
-    return S3Bucket.load(FLOW_STORAGE_BLOCK_PREFIX + suffix)
 
 
 def parse_docstring_fields(function, fields):

--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -338,7 +338,7 @@ def _deploy_to_worker(
         entrypoint=f"{module_name}.py:{flow_function_name}",
     )
     flow_obj.name = flow_name
-    work_pool_name = f"open-shift-{label}"
+    work_pool_name = f"k8s-{label}"
     deployment_id = flow_obj.deploy(
         name=deployment_name,
         work_pool_name=work_pool_name,


### PR DESCRIPTION
This PR, once installed/deployed, will cause all deployments to use a Kubernetes Work Pool running on OpenShift instead of a Docker Agent running on our Linux VM. It will also switch us from using MinIO for flow storage to using Github instead. It still uses MinIO for result storage.

Impacts:
- When you deploy or run a flow from the command line using this release, your Github working tree must be clean, meaning all changes committed and pushed. And then the deployment will use the code from Github to run the flow.
- This means you only need to deploy a flow once, and then subsequent pushes to Github will automatically update the deployment without the need to redeploy.
- If you use the run command, it will still delete the deployment when finished for the sake of convenience. Redeploying and deleting the deployment each time you run a flow on a dev branch is not a big deal, especially since deploying from Github is faster than using MinIO
- We will have to be more diligent about deleting dev deployments when no longer needed (if you aren't using "run"), and also about deleting Github branches we just used for testing purposes.
- The way images are used is not changing. You can still use the --image-branch option to deploy with a different image than the default:main one.
- You can still use the --label option to deploy from the main branch as if it were a dev branch or a dev branch as if it were a main branch. This is just to either A) test from main without sending an error message to Teams or B) test a dev branch on the main infrastructure to test things like firewall connections.
- All flows will have a max memory usage of 16 GB. If a flow uses too much memory, Prefect will show it as Crashed. When you click into the Details tab on the flow run in Prefect Cloud, it will tell you `Flow run process exited with non-zero status code -9`, indicating the process was killed by the operating system (due to hitting the memory limit).

Deployment steps (see oit-ds-apps-prefect for more info):
  - [ ] Ensure all worker helm charts are deployed
  - [ ] Ensure the prod namespace has the needed secrets (dev is already done)
  - [ ] Ensure all work pools are created
  - [ ] Ensure PE has set the needed resource quotas and limit ranges for the namespaces
  - [ ] Merge this PR and create the appropriate release
  - [ ] Commit the appropriate changes in the images repo to rebuild main:default with this release, along with the prefect-aws package
  - [ ] Tell everyone to reinstall the requirements for the main:default image so they will start deploying with the new release
  - [ ] Make a plan to test and deploy each existing flow onto the new infrastructure (create a tracking spreadsheet to share progress)