### PR TITLE
add append_clause argument for inserts

### DIFF
--- a/ucb_prefect_tools/database.py
+++ b/ucb_prefect_tools/database.py
@@ -333,7 +333,7 @@ def oracle_insert(
     errors = 0
     insert_sql = (
         f'INSERT INTO {table_identifier} ({",".join(list(dataframe.columns))}) '
-        + f'VALUES ({",".join(":" + i for i in dataframe.columns)})'
+        + f'VALUES ({",".join(":" + i for i in dataframe.columns)}) '
         + append_clause
     )
     _prepare_oracle_connection(connection_info)
@@ -749,7 +749,7 @@ def get_insert(system_type, connection_func):
         if system_type == "ODBC":
             insert_sql = (
                 f'INSERT INTO {table_identifier} ({",".join(list(dataframe.columns))}) '
-                + f'VALUES ({",".join(["?"] * len(dataframe.columns))})'
+                + f'VALUES ({",".join(["?"] * len(dataframe.columns))}) '
                 + append_clause
             )
             records = [[_cast(j) for j in i] for i in dataframe.values.tolist()]
@@ -757,7 +757,7 @@ def get_insert(system_type, connection_func):
             param_list = [f"%({i})s" for i in dataframe.columns]
             insert_sql = (
                 f'INSERT INTO {table_identifier} ({",".join(list(dataframe.columns))}) '
-                + f'VALUES ({",".join(param_list)})'
+                + f'VALUES ({",".join(param_list)}) '
                 + append_clause
             )
             records = [

--- a/ucb_prefect_tools/database.py
+++ b/ucb_prefect_tools/database.py
@@ -329,8 +329,10 @@ def oracle_insert(
     # pylint:disable=too-many-locals
     # pylint:disable=too-many-arguments
 
-    if on_conflict != "":
-        raise NotImplementedError("This database type does not support conflict resolution on insert")
+    if on_conflict:
+        raise NotImplementedError(
+            "This database type does not support conflict resolution on insert"
+        )
 
     batch_size = 500
     errors = 0
@@ -558,7 +560,7 @@ def snowflake_insert(
     pre_insert_statements: list[str] = None,
     pre_insert_params: list = None,
     max_error_proportion: float = 0.05,  # Not implemented!
-    on_conflict: str = ""
+    on_conflict: str = "",
 ) -> pd.DataFrame:
     """Snowflake-specific implementation of the insert task. This is the one task for Snowflake
     that needs to be custom-defined because inserting large amounts of data requires the use of
@@ -573,8 +575,10 @@ def snowflake_insert(
             "The max_error_proportion parameter is not supported for Snowflake databases due to how"
             " errors are handled within a transaction."
         )
-    if on_conflict != "":
-        raise NotImplementedError("This database type does not support conflict resolution on insert")
+    if on_conflict:
+        raise NotImplementedError(
+            "This database type does not support conflict resolution on insert"
+        )
 
     # Parse the schema and table name and validate to avoid sql injection attacks
     schema, table = table_identifier.split(".")


### PR DESCRIPTION
# Purpose

Adds the ability to place a clause after insert statements, primarily for automatic conflict resolution.

# Testing

Tested on a subset of sql inserts for our most common flavors.

# To-do

 - [ ] merge
 - [ ] create release
 - [ ] rebuild image
 - [ ] monitor for failures