### PR TITLE
Refactor parse_docstring_fields to take a string

### DIFF
--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -285,11 +285,7 @@ def _deploy(flow_filename, flow_function_name, image_name, image_branch, label="
             flow_func = getattr(module, flow_function_name)
 
         # Parse docstring fields and action on them as appropriate
-        required_fields = ["schedule", "image_name", "main_params"]
-        optional_fields = ["tags", "source_systems", "sink_systems", "customer_contact"]
-        docstring_fields = parse_docstring_fields(
-            flow_func, required_fields, optional_fields
-        )
+        docstring_fields = parse_docstring_fields(inspect.getdoc(flow_func))
 
         # Validate and apply docstring fields
         flow_tags = [label]
@@ -405,11 +401,9 @@ def _get_repo_info():
     return label, repo_short_name, branch_name
 
 
-def parse_docstring_fields(
-    function: callable, required_fields: list, optional_fields: list
-):
+def parse_docstring_fields(docstring: str):
     """Looks at the given function docstring and extracts any Sphinx-style field labels (like
-    `:tags: crm-ops`) from the docstring that match those listed by `fields`. If field is not
+    `:tags: crm-ops`) from the docstring that match the expected fields. If field is not
     present in the docstring, its value is set to None. Finally, return a dictionary mapping field
     keys to values from the actual docstring.
 
@@ -422,7 +416,8 @@ def parse_docstring_fields(
     Raises ValueError if a required field is not in the docstring.
     """
 
-    docstring = inspect.getdoc(function)
+    required_fields = ["schedule", "image_name", "main_params"]
+    optional_fields = ["tags", "source_systems", "sink_systems", "customer_contact"]
     all_fields = list(set(optional_fields + required_fields))
     result = {}
     if docstring:
@@ -464,6 +459,7 @@ def parse_docstring_fields(
         # We've reached the end of the document, so tie off the last field we were capturing
         if field:
             result[field] = " ".join(value).strip()
+            print(result[field])
 
     # Check that all required fields were found
     for field in required_fields:

--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -401,7 +401,17 @@ def _get_repo_info():
     return label, repo_short_name, branch_name
 
 
-def parse_docstring_fields(docstring: str):
+# Use immutable tuples as default values to avoid dangerous-default-arg
+def parse_docstring_fields(
+    docstring: str,
+    required_fields: list[str] = ("schedule", "image_name", "main_params"),
+    optional_fields: list[str] = (
+        "tags",
+        "source_systems",
+        "sink_systems",
+        "customer_contact",
+    ),
+):
     """Looks at the given function docstring and extracts any Sphinx-style field labels (like
     `:tags: crm-ops`) from the docstring that match the expected fields. If field is not
     present in the docstring, its value is set to None. Finally, return a dictionary mapping field
@@ -416,8 +426,6 @@ def parse_docstring_fields(docstring: str):
     Raises ValueError if a required field is not in the docstring.
     """
 
-    required_fields = ["schedule", "image_name", "main_params"]
-    optional_fields = ["tags", "source_systems", "sink_systems", "customer_contact"]
     all_fields = list(set(optional_fields + required_fields))
     result = {}
     if docstring:

--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -404,8 +404,8 @@ def _get_repo_info():
 # Use immutable tuples as default values to avoid dangerous-default-arg
 def parse_docstring_fields(
     docstring: str,
-    required_fields: list[str] = ("schedule", "image_name", "main_params"),
-    optional_fields: list[str] = (
+    required_fields: tuple[str] = ("schedule", "image_name", "main_params"),
+    optional_fields: tuple[str] = (
         "tags",
         "source_systems",
         "sink_systems",


### PR DESCRIPTION
This PR makes it easier to invoke the parse_docstring_fields function in outside flows and scripts so that we can consistently parse docstrings the same way in other places (such as the oit-ds-flows-monitoring repo). No actual impact to the functionality of deployments. I tested this as part of my PR for the oit-ds-flows-monitoring repo, although this can be deployed independently.

Deploy steps:

- [ ] Merge
- [ ] Create a new bugfix release pointing to the latest commit
- [ ] Update the oit-ds-tools-prefect-images repo to reference the new release in the default-image branch. This may be an opportunity to also merge any approved PRs in that repo and/or address any dependabot alerts.
- [ ] Tell everyone they may optionally update their local prefect tools package. Optional because there is no actual impact.