### PR TITLE
Add support for infra docstring field

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ucb_prefect_tools
-version = 6.2.0
+version = 6.3.0
 author = James Ashby
 author_email = james.ashby@colorado.edu
 description = Tasks and tools for implementing Prefect data flows

--- a/ucb_prefect_tools/util.py
+++ b/ucb_prefect_tools/util.py
@@ -220,11 +220,8 @@ def run_flow_command_line_interface(
             parsed_args.work_pool,
         )
     if parsed_args.command == "run":
-        if git.Repo().active_branch.name == "main" and parsed_args.label == "infer":
-            raise RuntimeError(
-                "Command `run` not allowed from main branch unless you specify an alternate "
-                "`--label`"
-            )
+        if git.Repo().active_branch.name == "main":
+            raise RuntimeError("Command `run` not allowed from main branch")
         deployment_id = _deploy(
             flow_filename,
             flow_function_name,


### PR DESCRIPTION
This PR adds support for a new `:infra:` field to flow docstrings. The infra field lets you specify what type of work pool the flow should run on. If you are on the main git branch and your docstring has `:infra: k8s` then the flow will be deployed to the `k8s-main` work pool. On any other git branch it will be deployed to the `k8s-dev` work pool. This allows us to have some flows running on OpenShift and others running on a VM or another system based on resource usage.

Before this change the `--label` command-line option was already getting confusing, and the addition of this change just makes things worse. So I also replaced this cl option with a new one: `--work-pool`. This lets you directly override the work pool that you want the flow to be deployed to.

I also added protection so that none of the command-line deployment options can be used on the main branch: the main branch should always be deployed based on the docstring settings. On any other branch you can use the command-line to override settings and facilitate testing.

I tested this locally and didn't find any issues.

For now I am making `:infra:` an optional field so that we can merge and release this version without breaking any flows. After updating all our flows to use this label, we can go back and make it required for the sake of clarity.

Deployment steps:

- [ ] Merge
- [ ] Create a new release for it
- [ ] Update the prefect-images repo to point to the new release.
- [ ] Notify the team to install the new release.
- [ ] Add an `infra` column to the orchestration.flows tables (all three databases) in Snowflake

Future steps: Work on updating docstrings and getting the flows still running on the old vm to use this deployment method. This will require changing the "agent" work pool names to match the new convention.